### PR TITLE
Add support for .net8

### DIFF
--- a/DevProxy.Hosting/DevProxy.Hosting.csproj
+++ b/DevProxy.Hosting/DevProxy.Hosting.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>Dev Proxy</Authors>
     <Title>Dev Proxy .NET Aspire extensions</Title>
     <Description>.NET Aspire extensions for adding Dev Proxy as a resource to your .NET Aspire application.</Description>


### PR DESCRIPTION
This pull request introduces support for .NET 8 (LTS version of .NET). 
The changes have been successfully tested using a local Aspire project that integrates with DevProxy. Both the executable and containerized versions of the application were verified and are working as expected.